### PR TITLE
[33기 김슬비] ADD : 소셜 로그인 기능구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/Router.js
+++ b/src/Router.js
@@ -6,6 +6,8 @@ import ItemList from './pages/main/components/itemList/ItemList';
 import Footer from './components/footer/Footer';
 import Buy from './pages/deals/Buy';
 import Nav from './components/nav/Nav';
+import Login from './pages/users/login/Login';
+import Redirect from './pages/users/Redirect';
 
 function Router() {
   return (
@@ -16,6 +18,8 @@ function Router() {
         <Route path="/goodsdetail" element={<GoodsDetail />} />
         <Route path="/buy" element={<Buy />} />
         <Route path="/products" element={<ItemList />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/users/signin/kakao/callback" element={<Redirect />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -1,37 +1,13 @@
 import React, { useEffect, useState } from 'react';
-// import { API } from '../../../src/config.js';
-// import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Nav = () => {
   const [isLogin, setIsLogin] = useState(false);
   const creamToken = localStorage.getItem('cream_token');
-  // const navigate = useNavigate();
 
   useEffect(() => {
     creamToken && setIsLogin(true);
   }, []);
-
-  // 마이페이지 제작 후 처리할 로직
-  // const goToMypage = () => {
-  //   creamToken
-  //     ? fetch(`${API.USERS}`, {
-  //         method: 'GET',
-  //         headers: {
-  //           Authorization: creamToken,
-  //         },
-  //       })
-  //         .then(res => {
-  //           if (res.ok) {
-  //             return res.json();
-  //           }
-  //         })
-  //         .then(() => {
-  //           console.log('');
-  //           navigate('/마이페이지');
-  //         })
-  //     : navigate(`/login`);
-  // };
 
   return (
     <Container>
@@ -40,17 +16,7 @@ const Nav = () => {
         <Button>STYLE</Button>
         <Button>SHOP</Button>
         <Button>ABOUT</Button>
-        {isLogin ? (
-          <Button
-          // onClick={() => {
-          //   goToMypage();
-          // }}
-          >
-            MYPAGE
-          </Button>
-        ) : (
-          <Button login>LOGIN</Button>
-        )}
+        {isLogin ? <Button>MYPAGE</Button> : <Button login>LOGIN</Button>}
       </ButtonContainer>
     </Container>
   );

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,6 @@
-export const BASE_URL = 'http://10.58.5.138:8000/';
+export const BASE_URL = 'http://13.125.248.213:8000/';
 
 export const API = {
   USERS: `${BASE_URL}users`,
   KAKAO_LOGIN: `${BASE_URL}users/login/kakao`,
-  KAKAO_TOKEN: `https://kauth.kakao.com/oauth/token`,
 };

--- a/src/pages/users/Redirect.js
+++ b/src/pages/users/Redirect.js
@@ -1,0 +1,62 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { API } from '../../config';
+
+const Redirect = () => {
+  const url = new URL(window.location.href);
+  const code = url.searchParams.get('code');
+  const navigate = useNavigate();
+
+  const getToken = () => {
+    fetch(`${API.KAKAO_LOGIN}?code=${code}`, {
+      method: 'GET',
+    })
+      .then(res => {
+        if (res.status === 200) {
+          return res.json();
+        } else {
+          navigate('/login');
+          alert('다시 로그인 해주세요');
+        }
+      })
+      .then(data => {
+        localStorage.setItem('cream_token', data.cream_token);
+        navigate('/');
+      });
+  };
+
+  useEffect(() => {
+    getToken();
+  }, []);
+
+  return (
+    <SpinnerContainer>
+      <Spinner />
+    </SpinnerContainer>
+  );
+};
+
+const SpinnerContainer = styled.div`
+  ${props => props.theme.flex.flexBox()}
+  height: 100vh;
+`;
+
+const Spinner = styled.div`
+  width: 60px;
+  height: 60px;
+  border: 5px solid lightgray;
+  border-radius: 50%;
+  border-top: 5px solid white;
+  animation: spin 1s linear infinite;
+
+  @keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+export default Redirect;

--- a/src/pages/users/login/Login.js
+++ b/src/pages/users/login/Login.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+import { KAKAO_AUTH_URL } from './LoginData';
+
+const Login = () => {
+  return (
+    <Container>
+      <Logo>CREAM</Logo>
+
+      <LoginForm>
+        <Label htmlFor="id">이메일 주소</Label>
+        <Input
+          id="id"
+          placeholder="예) cream@cream.co.kr"
+          onfocus="placeholder = ''"
+        />
+      </LoginForm>
+
+      <LoginForm>
+        <Label htmlFor="pw">비밀번호</Label>
+        <Input id="pw" />
+      </LoginForm>
+
+      <LoginBtn>로그인</LoginBtn>
+      <KakaoBtn as="a" href={KAKAO_AUTH_URL}>
+        카카오로 로그인
+      </KakaoBtn>
+    </Container>
+  );
+};
+
+const Container = styled.section`
+  ${props => props.theme.flex.flexBox('column')}
+  margin: auto;
+  margin-top: 9.375rem;
+  max-width: 25rem;
+`;
+
+const Logo = styled.h1`
+  margin-bottom: 2.8rem;
+  font-size: ${props => props.theme.fontSizes.titleSize};
+  font-weight: bold;
+`;
+
+const LoginForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: ${props => props.theme.margins.xxl};
+  width: 100%;
+  height: 4.375rem;
+`;
+
+const Label = styled.label`
+  font-size: ${props => props.theme.fontSizes.small};
+  padding-bottom: ${props => props.theme.paddings.base};
+`;
+
+const Input = styled.input`
+  border: none;
+  border-bottom: 1px solid #ebebeb;
+  padding: ${props => props.theme.paddings.base} 0;
+  font-size: ${props => props.theme.fontSizes.small};
+
+  &:focus {
+    outline: none;
+    border-bottom: 2px solid black;
+
+    ::placeholder {
+      opacity: 0;
+    }
+  }
+
+  ::placeholder {
+    color: #bbb;
+    opacity: 1;
+  }
+`;
+
+const LoginBtn = styled.button`
+  background: #ebebeb;
+  width: 100%;
+  margin: ${props => props.theme.margins.xl};
+  padding: ${props => props.theme.paddings.large};
+  border: none;
+  border-radius: 10px;
+  font-size: ${props => props.theme.fontSizes.base};
+  color: ${props => props.theme.colors.white};
+  cursor: pointer;
+`;
+
+const KakaoBtn = styled(LoginBtn)`
+  margin-top: -0.625rem;
+  border: ${props => props.theme.borders.lightGray};
+  background: transparent;
+  color: black;
+  text-align: center;
+  text-decoration: none;
+`;
+
+export default Login;

--- a/src/pages/users/login/LoginData.js
+++ b/src/pages/users/login/LoginData.js
@@ -1,0 +1,5 @@
+export const REDIRECT_URI = 'http://localhost:3000/users/signin/kakao/callback';
+
+export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;
+
+export const KAKAO_TOKEN = 'https://kauth.kakao.com/oauth/token';

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -16,6 +16,7 @@ const GlobalStyle = createGlobalStyle`
   h1 {
     font-family: 'Viga', sans-serif;
   }
+
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 소셜 로그인 기능구현 (카카오)


<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1) login 페이지 구현
2) 소셜로그인 기능 구현
- 카카오계정과 애플리케이션을 연결하고 토큰을 발급받아 카카오 API를 사용할 수 있도록 하는 기능을 구현한다.

<br/>

- 시도1_프론트단에서 액세스토큰까지 받는 과정)
1단계: 카카오에서 인증코드를 받아오기
2단계: 카카오에서 받아온 인증코드를 다시 카카오에게 보내서 토큰을 요청하기
3단계: 카카오에서 받은 카카오 토큰을 백엔드 서버에 넘겨서 토큰 요청 받아오기
4단계: 받아온 토큰을 로컬스토리지에 저장하기
5단계: 로컬스토리지에 저장된 토큰 유무에 따른 nav bar 로그인/로그아웃 표시 바꾸기

<br/>

- 시도2_프론트단에서 인가코드까지만 받아서 넘겨주는 과정으로 진행 v

<br/>

- 인가 코드를 받아오는 단계, 액세스토큰을 받아오는 단계 ) 인가코드를 받아와서 백엔드 서버로 코드를 넘겨준다.
- 인가 코드 받기: 카카오 로그인 동의 화면을 호출하고, 사용자 동의를 거쳐 인가 코드 발급을 요청한다.
- 토큰 받기: 인가 코드로 액세스 토큰과 리프레시 토큰 발급을 요청한다.
- 분기 처리: 요청이 성공적으로 완료되면 진행되고 그렇지 않으면 알림창과 함께 로그인 페이지로 이동된다.

<br/>

3) 로딩스피너 페이지 추가
- 사용자가 로그인 접속을 거쳐서 메인페이지로 넘어가기 전에 보여줄 페이지에 로딩 스피너 UI를 작성한다.


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 프론트단에서 토큰 발급단계까지 구현 후 로컬스토리지에 토큰을 두 번 저장해야 하는 이슈가 생겨서 인가토큰 발급까지만 받고 넘기는 것으로 수정했다. 이 부분에서 프론트 백엔드 사이에서의 역할과 협업에 대해 배울 수 있었다.
 +) 로컬스토리지에 저장하는 부분은 백엔드로부터 받은 최종 사이트 토큰만 저장해도 된다는 피드백을 얻었다.
- 공식 API 명세서를 읽고 API활용하는 법에 대해 익힐 수 있었다.
- cors 에러가 뜬 상황에서 백엔드 파트너와 함께 개발자도구로 에러 코드를 알아내고 API 명세서를 통해 에러를 분석&해결할 수 있었다.

<br />

## :: 기타 질문 및 특이 사항

